### PR TITLE
Set $GRAFFITI variable to max 32 chars.

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -6,6 +6,7 @@ fields:
       name: GRAFFITI
       service: validator
     title: Graffiti
+    maxLength: 32
     description: >-
       Add a string to your proposed blocks, which will be seen on the block explorer
   - id: HTTP_WEB3PROVIDER


### PR DESCRIPTION
In response to dappnode/DAppNode#363 This should limit the field in one of 2 spots where graffiti can be entered. The other is in the config tab of the prysm application. Should also be done for Prysm Pyrmont if it was going to be supported anymore.