### PR TITLE
Eth2 migrate to web3signer

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,1 +1,5 @@
-If you want to have the complete dashboard with all the metrics you will have to install [metrics-tools](http://my.dappnode/#/installer/metrics-tools.dnp.dappnode.eth) (Grafana dashboard thanks to amazing work of [metanull-operator](https://github.com/metanull-operator/eth2-grafana))
+## Welcome to your eth2 client Prysm-prater:
+
+- Upload your keystores in the [web3signer-ui](http://ui.web3signer-prater.dappnode?signer_url=http://web3signer.web3signer-prater.dappnode:9000) (do not have web3singer yet? install it [here](http://my.dappnode/#/installer/web3signer-prater.dnp.dappnode.eth))
+
+- If you want to have the complete dashboard with all the metrics you will have to install [metrics-tools](http://my.dappnode/#/installer/metrics-tools.dnp.dappnode.eth) (Grafana dashboard thanks to amazing work of [metanull-operator](https://github.com/metanull-operator/eth2-grafana))

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,5 +1,1 @@
-- **Is your first login?** use the link with the token attached below.  For more information and a full guide on the new method of accessing the Prysm Prater Dashboard visit this forum [post](https://forum.dappnode.io/t/how-to-access-the-prysm-prater-webui-in-v0-1-5-upstream-v2-0-3-and-above/1304)
-
-- If you have already logged in with the token go to [prysm-prater.dappnode](http://prysm-prater.dappnode/)
-
-- If you want to have the complete dashboard with all the metrics you will have to install [metrics-tools](http://my.dappnode/#/installer/metrics-tools.dnp.dappnode.eth) (Grafana dashboard thanks to amazing work of [metanull-operator](https://github.com/metanull-operator/eth2-grafana))
+If you want to have the complete dashboard with all the metrics you will have to install [metrics-tools](http://my.dappnode/#/installer/metrics-tools.dnp.dappnode.eth) (Grafana dashboard thanks to amazing work of [metanull-operator](https://github.com/metanull-operator/eth2-grafana))

--- a/README.md
+++ b/README.md
@@ -9,9 +9,18 @@ Validate with prysm: a Go implementation of the Ethereum 2.0 Serenity protocol a
 
 ![avatar](avatar-prysm-prater.png)
 
-
 Grafana dashboard thanks to the amazing work of [metanull-operator](https://github.com/metanull-operator/eth2-grafana)
 
-|      Updated       |   Champion/s   |
-| :----------------: | :------------: |
-| :heavy_check_mark: | @tropicar |
+|      Updated       | Champion/s |
+| :----------------: | :--------: |
+| :heavy_check_mark: | @tropicar  |
+
+### Development
+
+1. Select a Prysm branch, current work progress use to be tracked at `develop` branch. Set the branch env in the `docker-compose.dev.yml`
+
+2. Build Prysm with the branch defined with
+
+```
+npx @dappnode/dappnodesdk build --compose_file_name=docker-compose.dev.yml
+```

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "prysm-prater.dnp.dappnode.eth",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "upstreamVersion": "v2.0.6",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/dappnode/DAppNodePackage-prysm-prater/issues"
   },
   "requirements": {
-    "minimumDappnodeVersion": "0.2.39"
+    "minimumDappnodeVersion": "0.2.52"
   },
   "backup": [
     {
@@ -40,6 +40,7 @@
     "docs": "https://docs.prylabs.network/docs/getting-started"
   },
   "dependencies": {
+    "web3signer-prater.dnp.dappnode.eth": "latest",
     "goerli-geth.dnp.dappnode.eth": "latest"
   }
 }

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -35,7 +35,6 @@
   ],
   "categories": ["Blockchain", "ETH2.0"],
   "links": {
-    "ui": "http://prysm-prater.dappnode/",
     "homepage": "https://prysmaticlabs.com/",
     "readme": "https://github.com/dappnode/DAppNodePackage-prysm-prater",
     "docs": "https://docs.prylabs.network/docs/getting-started"

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -40,7 +40,6 @@
     "docs": "https://docs.prylabs.network/docs/getting-started"
   },
   "dependencies": {
-    "web3signer-prater.dnp.dappnode.eth": "latest",
     "goerli-geth.dnp.dappnode.eth": "latest"
   }
 }

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/dappnode/DAppNodePackage-prysm-prater/issues"
   },
   "requirements": {
-    "minimumDappnodeVersion": "0.2.52"
+    "minimumDappnodeVersion": "0.2.51"
   },
   "backup": [
     {

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "prysm-prater.dnp.dappnode.eth",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "upstreamVersion": "v2.0.6",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
@@ -35,6 +35,7 @@
   ],
   "categories": ["Blockchain", "ETH2.0"],
   "links": {
+    "ui": "http://ui.web3signer-prater.dappnode?signer_url=http://web3signer.web3signer-prater.dappnode:9000",
     "homepage": "https://prysmaticlabs.com/",
     "readme": "https://github.com/dappnode/DAppNodePackage-prysm-prater",
     "docs": "https://docs.prylabs.network/docs/getting-started"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,8 +20,10 @@ services:
     image: "validator.prysm-prater.dnp.dappnode.eth:0.2.0"
     build:
       context: validator
+      dockerfile: Dockerfile.dev
       args:
         UPSTREAM_VERSION: v2.0.6
+        BRANCH: develop
     volumes:
       - "validator-data:/root/"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,15 @@ services:
     image: "validator.prysm-prater.dnp.dappnode.eth:0.2.0"
     build:
       context: validator
+      dockerfile: Dockerfile.dev
       args:
         UPSTREAM_VERSION: v2.0.6
+        BRANCH: develop
     volumes:
       - "validator-data:/root/"
     restart: unless-stopped
     environment:
-      WALLET_DIR: "/root/.eth2validators"
+      WALLET_DIR: /root/.eth2validators
       BEACON_RPC_PROVIDER: "beacon-chain.prysm-prater.dappnode:4000"
       BEACON_RPC_GATEWAY_PROVIDER: "beacon-chain.prysm-prater.dappnode:3500"
       HTTP_WEB3SIGNER: "http://web3signer.web3signer-prater.dappnode:9000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,16 @@ services:
         UPSTREAM_VERSION: v2.0.6
     volumes:
       - "validator-data:/root/"
+      - "validator-keys:/root/public-keys"
     restart: unless-stopped
     environment:
       BEACON_RPC_PROVIDER: "beacon-chain.prysm-prater.dappnode:4000"
       BEACON_RPC_GATEWAY_PROVIDER: "beacon-chain.prysm-prater.dappnode:3500"
+      HTTP_WEB3SIGNER: "http://web3signer.web3signer-prater.dappnode:9000"
+      PUBLIC_KEYS_FILE: /root/public-keys/public_keys.txt
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
 volumes:
   beacon-chain-data: {}
   validator-data: {}
+  validator-keys: {}

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 FROM debian:buster-slim
 
 RUN apt update && \
-  apt install -y ca-certificates file git curl cron jq && \
+  apt install -y ca-certificates file git curl cron jq unzip && \
   rm -rf /var/lib/apt/lists/*
 
 #Copy binaries from build stage
@@ -23,6 +23,9 @@ COPY get-keys-cron /etc/cron.d/
 COPY get-keys.sh /usr/local/bin/get-keys.sh
 # Apply cron job
 RUN crontab /etc/cron.d/get-keys-cron
+
+# Copy migration script
+COPY eth2-migrate.sh /usr/local/bin
 
 # Copy entrypoint script
 COPY entrypoint.sh /usr/local/bin

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -12,11 +12,17 @@ RUN DEBIAN_FRONTEND=noninteractive \
 FROM debian:buster-slim
 
 RUN apt update && \
-  apt install -y ca-certificates file git curl && \
+  apt install -y ca-certificates file git curl cron jq && \
   rm -rf /var/lib/apt/lists/*
 
 #Copy binaries from build stage
 COPY --from=binary /usr/local/bin/validator /usr/local/bin
+
+# Setup cronjob
+COPY get-keys-cron /etc/cron.d/
+COPY get-keys.sh /usr/local/bin/get-keys.sh
+# Apply cron job
+RUN crontab /etc/cron.d/get-keys-cron
 
 # Copy entrypoint script
 COPY entrypoint.sh /usr/local/bin

--- a/validator/Dockerfile.dev
+++ b/validator/Dockerfile.dev
@@ -1,0 +1,38 @@
+###########
+# BUILDER #
+###########
+FROM golang as builder
+
+ARG BRANCH
+
+WORKDIR /usr/src/app
+RUN apt update && git clone https://github.com/prysmaticlabs/prysm.git
+RUN cd prysm && git checkout $BRANCH
+WORKDIR /usr/src/app/prysm/cmd/validator
+RUN go build -o ./tmp/validator && chmod +x /usr/src/app/prysm/cmd/validator/tmp/validator
+
+##########
+# RUNNER #
+##########
+FROM debian:buster-slim
+
+RUN apt update && \
+  apt install -y ca-certificates file git curl cron jq unzip && \
+  rm -rf /var/lib/apt/lists/*
+
+#Copy binaries from build stage
+COPY --from=builder /usr/src/app/prysm/cmd/validator/tmp/validator /usr/local/bin
+
+# Setup cronjob
+COPY get-keys-cron /etc/cron.d/
+COPY get-keys.sh /usr/local/bin/get-keys.sh
+# Apply cron job
+RUN crontab /etc/cron.d/get-keys-cron
+
+# Copy migration script
+COPY eth2-migrate.sh /usr/local/bin
+
+# Copy entrypoint script
+COPY entrypoint.sh /usr/local/bin
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -1,42 +1,97 @@
 #!/bin/bash
 
-# Paths
-AUTH_TOKEN_DIR="/root/.eth2validators"
-AUTH_TOKEN_FILE="${AUTH_TOKEN_DIR}/auth-token"
-TOKEN=""
+ERROR="[ ERROR ]"
+WARN="[ WARN ]"
+INFO="[ INFO ]"
 
-# Generate JWT if does not exist already
-if [ ! -f "${AUTH_TOKEN_FILE}" ]; then
-    echo "[INFO] generating JWT..."
-    mkdir -p "${AUTH_TOKEN_DIR}"
-    # --wallet-dir value   Path to a wallet directory on-disk for Prysm validator accounts (default: "/root/.eth2validators/prysm-wallet-v2")
-    validator web generate-auth-token --wallet-dir=${AUTH_TOKEN_DIR} --accept-terms-of-use || { echo "[ERROR] failed to generate JWT"; exit 1; }
+# Var used to start the teku validator: pubkeys must be comma separated
+PUBLIC_KEYS_COMMA_SEPARATED=""
+
+# Checks the following vars exist or exits:
+# - BEACON_RPC_PROVIDER
+# - BEACON_RPC_GATEWAY_PROVIDER
+# - HTTP_WEB3SIGNER
+# - PUBLIC_KEYS_FILE
+function ensure_envs_exist() {
+    [ -z "${BEACON_RPC_PROVIDER}" ] && echo "${ERROR} BEACON_RPC_PROVIDER is not set" && exit 1
+    [ -z "${BEACON_RPC_GATEWAY_PROVIDER}" ] && echo "${ERROR} BEACON_RPC_GATEWAY_PROVIDER is not set" && exit 1
+    [ -z "${HTTP_WEB3SIGNER}" ] && echo "${ERROR} HTTP_WEB3SIGNER is not set" && exit 1
+    [ -z "${PUBLIC_KEYS_FILE}" ] && echo "${ERROR} PUBLIC_KEYS_FILE is not set" && exit 1
+}
+
+# Get public keys from API keymanager: BASH ARRAY OF STRINGS
+# - Endpoint: http://web3signer.web3signer-prater.dappnode:9000/eth/v1/keystores
+# - Returns:
+# { "data": [{
+#     "validating_pubkey": "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a",
+#     "derivation_path": "m/12381/3600/0/0/0",
+#     "readonly": true
+#     }]
+# }
+function get_public_keys() {
+    if PUBLIC_KEYS=$(curl -s -X GET \
+    -H "Content-Type: application/json" \
+    --max-time 10 \
+    --retry 2 \
+    --retry-delay 2 \
+    --retry-max-time 40 \
+    "${HTTP_WEB3SIGNER}/eth/v1/keystores"); then
+        if PUBLIC_KEYS_PARSED=$(echo ${PUBLIC_KEYS} | jq -r '.data[].validating_pubkey'); then
+            if [ ! -z "$PUBLIC_KEYS_PARSED" ]; then
+                echo "${INFO} found public keys: $PUBLIC_KEYS_PARSED"
+            else
+                echo "${WARN} no public keys found"
+            fi
+        else
+            echo "${WARN} something wrong happened parsing the public keys"
+        fi
+    else
+        echo "${WARN} web3signer not available"
+    fi
+}
+
+# Clean old file and writes new public keys file
+# - by new line separated
+# - creates file if it does not exist
+function write_public_keys() {
+    # Clean file
+    rm -rf ${PUBLIC_KEYS_FILE}
+    touch ${PUBLIC_KEYS_FILE}
+
+    echo "${INFO} writing public keys to file"
+    for PUBLIC_KEY in ${PUBLIC_KEYS_PARSED}; do
+        if [ ! -z "${PUBLIC_KEY}" ]; then
+            echo "${INFO} adding public key: $PUBLIC_KEY"
+            echo "${PUBLIC_KEY}" >> ${PUBLIC_KEYS_FILE}
+        else
+            echo "${WARN} empty public key"
+        fi
+    done
+}
+
+
+########
+# MAIN #
+########
+
+# Check if the envs exist
+ensure_envs_exist
+
+# Get public keys from API keymanager
+get_public_keys
+
+if [ ! -z "${PUBLIC_KEYS_PARSED}" ]; then
+    # Write public keys to file
+    echo "${INFO} writing public keys file"
+    write_public_keys
+
+    # Create comma separated string of public keys
+    echo "${INFO} creating comma separated string of public keys"
+    PUBLIC_KEYS_COMMA_SEPARATED=$(echo ${PUBLIC_KEYS_COMMA_SEPARATED} | tr ' ' ',')
 fi
 
-# Print token
-TOKEN=$(sed -n 2p ${AUTH_TOKEN_FILE}) || { echo "[ERROR] failed to read JWT"; exit 1; }
-echo "[INFO] successfully detected JWT: ${TOKEN}"
-
-# Check if the token exists and post 
-# the url with the token to the dappmanager
-if [ ! -z "$TOKEN" ]; then
-    # Post JWT to dappmanager
-    curl --connect-timeout 5 \
-        --max-time 10 \
-        --retry 5 \
-        --retry-delay 0 \
-        --retry-max-time 40 \
-        -X POST "http://my.dappnode/data-send?key=token&data=http://prysm-prater.dappnode/initialize?token=${TOKEN}" \
-        || { echo "[ERROR] failed to post JWT to dappmanager"; exit 1; }
-
-else
-    { echo "[ERROR] could not find auth token file"; exit 1; }
-fi
-
-# Check vars 
-[ -z "$BEACON_RPC_PROVIDER" ] && { echo "[ERROR] BEACON_RPC_PROVIDER is not set"; exit 1; } || echo "[INFO] BEACON_RPC_PROVIDER ${BEACON_RPC_PROVIDER}"
-[ -z "$BEACON_RPC_GATEWAY_PROVIDER" ] && { echo "[ERROR] BEACON_RPC_GATEWAY_PROVIDER is not set"; exit 1; } || echo "[INFO] BEACON_RPC_GATEWAY_PROVIDER ${BEACON_RPC_GATEWAY_PROVIDER}"
-[ -z "$GRAFFITI" ] && echo "[WARN] GRAFFITI is not set" || echo "[INFO] GRAFFITI ${GRAFFITI}"
+echo "${INFO} starting cronjob"
+cron
 
 # Must used escaped \"$VAR\" to accept spaces: --graffiti=\"$GRAFFITI\"
 exec -c validator \
@@ -49,8 +104,9 @@ exec -c validator \
   --wallet-dir=/root/.eth2validators \
   --wallet-password-file=/root/.eth2wallets/wallet-password.txt \
   --write-wallet-password-on-web-onboarding \
+  --validators-external-signer-url=$HTTP_WEB3SIGNER \
+  --validators-external-signer-public-keys=$PUBLIC_KEYS_COMMA_SEPARATED \
   --graffiti="$GRAFFITI" \
-  --web \
   --grpc-gateway-host=0.0.0.0 \
   --grpc-gateway-port=80 \
   --accept-terms-of-use \

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -12,11 +12,13 @@ PUBLIC_KEYS_COMMA_SEPARATED=""
 # - BEACON_RPC_GATEWAY_PROVIDER
 # - HTTP_WEB3SIGNER
 # - PUBLIC_KEYS_FILE
+# - WALLET_DIR
 function ensure_envs_exist() {
-    [ -z "${BEACON_RPC_PROVIDER}" ] && echo "${ERROR} BEACON_RPC_PROVIDER is not set" && exit 1
-    [ -z "${BEACON_RPC_GATEWAY_PROVIDER}" ] && echo "${ERROR} BEACON_RPC_GATEWAY_PROVIDER is not set" && exit 1
-    [ -z "${HTTP_WEB3SIGNER}" ] && echo "${ERROR} HTTP_WEB3SIGNER is not set" && exit 1
-    [ -z "${PUBLIC_KEYS_FILE}" ] && echo "${ERROR} PUBLIC_KEYS_FILE is not set" && exit 1
+    [ -z "${BEACON_RPC_PROVIDER}" ] && { echo "${ERROR} BEACON_RPC_PROVIDER is not set"; exit 1; }
+    [ -z "${BEACON_RPC_GATEWAY_PROVIDER}" ] && { echo "${ERROR} BEACON_RPC_GATEWAY_PROVIDER is not set"; exit 1; }
+    [ -z "${HTTP_WEB3SIGNER}" ] && { echo "${ERROR} HTTP_WEB3SIGNER is not set"; exit 1; }
+    [ -z "${PUBLIC_KEYS_FILE}" ] && { echo "${ERROR} PUBLIC_KEYS_FILE is not set"; exit 1; }
+    [ -z "${WALLET_DIR}" ] && { echo "${ERROR} WALLET_DIR is not set"; exit 1; }
 }
 
 # Get public keys from API keymanager: BASH ARRAY OF STRINGS
@@ -28,38 +30,47 @@ function ensure_envs_exist() {
 #     "readonly": true
 #     }]
 # }
+#
+# IMPORTANT! Prysm validator-web3signer does not allow to start without public keys.
+# - Service must exit with 1 to keep the service restarting until there are uploaded validators on the web3signer.
+# - Prysm is about to change this behaviour: https://github.com/prysmaticlabs/prysm/issues/10293
 function get_public_keys() {
-    if PUBLIC_KEYS=$(curl -s -X GET \
-    -H "Content-Type: application/json" \
-    --max-time 10 \
-    --retry 2 \
-    --retry-delay 2 \
-    --retry-max-time 40 \
-    "${HTTP_WEB3SIGNER}/eth/v1/keystores"); then
-        if PUBLIC_KEYS_PARSED=$(echo ${PUBLIC_KEYS} | jq -r '.data[].validating_pubkey'); then
-            if [ ! -z "$PUBLIC_KEYS_PARSED" ]; then
-                echo "${INFO} found public keys: $PUBLIC_KEYS_PARSED"
+    # Try for 3 minutes    
+    while true; do
+        if PUBLIC_KEYS_API=$(curl -s -X GET \
+        -H "Content-Type: application/json" \
+        --retry 60 \
+        --retry-delay 3 \
+        --retry-connrefused \
+        "${HTTP_WEB3SIGNER}/eth/v1/keystores"); then
+            if PUBLIC_KEYS_API=$(echo ${PUBLIC_KEYS_API} | jq -r '.data[].validating_pubkey'); then
+                if [ ! -z "$PUBLIC_KEYS_API" ]; then
+                    PUBLIC_KEYS_COMMA_SEPARATED=$(echo ${PUBLIC_KEYS_API} | tr ' ' ',')
+                    { echo "${INFO} found public keys: $PUBLIC_KEYS_API"; break; }
+                else
+                    { echo "${WARN} no public keys found"; continue; }
+                fi
             else
-                echo "${WARN} no public keys found"
+                { echo "${WARN} something wrong happened parsing the public keys"; continue; }
             fi
         else
-            echo "${WARN} something wrong happened parsing the public keys"
+            { echo "${WARN} web3signer not available"; continue; }
+            
         fi
-    else
-        echo "${WARN} web3signer not available"
-    fi
+    done
 }
 
-# Clean old file and writes new public keys file
+function clean_public_keys() {
+    rm -rf ${PUBLIC_KEYS_FILE}
+    touch ${PUBLIC_KEYS_FILE}
+}
+
+# Writes public keys
 # - by new line separated
 # - creates file if it does not exist
 function write_public_keys() {
-    # Clean file
-    rm -rf ${PUBLIC_KEYS_FILE}
-    touch ${PUBLIC_KEYS_FILE}
-
     echo "${INFO} writing public keys to file"
-    for PUBLIC_KEY in ${PUBLIC_KEYS_PARSED}; do
+    for PUBLIC_KEY in ${PUBLIC_KEYS_API}; do
         if [ ! -z "${PUBLIC_KEY}" ]; then
             echo "${INFO} adding public key: $PUBLIC_KEY"
             echo "${PUBLIC_KEY}" >> ${PUBLIC_KEYS_FILE}
@@ -69,7 +80,6 @@ function write_public_keys() {
     done
 }
 
-
 ########
 # MAIN #
 ########
@@ -77,17 +87,27 @@ function write_public_keys() {
 # Check if the envs exist
 ensure_envs_exist
 
+# Migrate if required
+validator accounts list \
+    --wallet-dir="$WALLET_DIR" \
+    --wallet-password-file="${WALLET_DIR}/walletpassword.txt" \
+    --prater \
+    --accept-terms-of-use \
+    && { echo "${INFO} found validators, starging migration"; eth2-migrate.sh & wait $!; } \
+    || { echo "${INFO} validators not found, no migration needed"; }
+
 # Get public keys from API keymanager
 get_public_keys
 
-if [ ! -z "${PUBLIC_KEYS_PARSED}" ]; then
+# Clean old public keys
+clean_public_keys
+
+if [ ! -z "${PUBLIC_KEYS_API}" ]; then
     # Write public keys to file
     echo "${INFO} writing public keys file"
     write_public_keys
-
-    # Create comma separated string of public keys
-    echo "${INFO} creating comma separated string of public keys"
-    PUBLIC_KEYS_COMMA_SEPARATED=$(echo ${PUBLIC_KEYS_COMMA_SEPARATED} | tr ' ' ',')
+else
+    echo "${WARN} no public keys found"
 fi
 
 echo "${INFO} starting cronjob"
@@ -96,17 +116,15 @@ cron
 # Must used escaped \"$VAR\" to accept spaces: --graffiti=\"$GRAFFITI\"
 exec -c validator \
   --prater \
-  --datadir=/root/.eth2 \
+  --datadir="$WALLET_DIR" \
+  --wallet-dir="$WALLET_DIR" \
   --rpc-host 0.0.0.0 \
   --monitoring-host 0.0.0.0 \
   --beacon-rpc-provider="$BEACON_RPC_PROVIDER" \
   --beacon-rpc-gateway-provider="$BEACON_RPC_GATEWAY_PROVIDER" \
-  --wallet-dir=/root/.eth2validators \
-  --wallet-password-file=/root/.eth2wallets/wallet-password.txt \
-  --write-wallet-password-on-web-onboarding \
-  --validators-external-signer-url=$HTTP_WEB3SIGNER \
-  --validators-external-signer-public-keys=$PUBLIC_KEYS_COMMA_SEPARATED \
-  --graffiti="$GRAFFITI" \
+  --validators-external-signer-url="$HTTP_WEB3SIGNER" \
+  --validators-external-signer-public-keys="$PUBLIC_KEYS_COMMA_SEPARATED" \
+  --graffiti=\"$GRAFFITI\" \
   --grpc-gateway-host=0.0.0.0 \
   --grpc-gateway-port=80 \
   --accept-terms-of-use \

--- a/validator/eth2-migrate.sh
+++ b/validator/eth2-migrate.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# TODO:
+# - Implement int tests
+# - Implement unit tests
+
+#############
+# VARIABLES #
+#############
+
+ERROR="[ ERROR-migration ]"
+WARN="[ WARN-migration ]"
+INFO="[ INFO-migration ]"
+
+HTTP_WEB3SIGNER="http://web3signer.web3signer-prater.dappnode:9000"
+NETWORK="prater"
+WALLET_DIR="/root/.eth2validators"
+WALLETPASSWORD_FILE="${WALLET_DIR}/walletpassword.txt"
+BACKUP_DIR="${WALLET_DIR}/backup"
+BACKUP_ZIP_FILE="${BACKUP_DIR}/backup.zip"
+BACKUP_KEYSTORES_DIR="${BACKUP_DIR}/keystores" # Directory where the keystores are stored in format: keystore_0.json keystore_1.json ...
+BACKUP_SLASHING_FILE="${BACKUP_DIR}/slashing_protection.json"
+BACKUP_WALLETPASSWORD_FILE="${BACKUP_DIR}/walletpassword.txt"
+
+#############
+# FUNCTIONS #
+#############
+
+# Ensure requirements
+function ensure_requirements() {
+    # Try for 3 minutes 
+    # Check if web3signer is available: https://consensys.github.io/web3signer/web3signer-eth2.html#tag/Server-Status
+    if [ $(curl -s -X GET \
+    -H "Content-Type: application/json" \
+    --write-out '%{http_code}' \
+    --silent \
+    --output /dev/null \
+    --retry 30 \
+    --retry-delay 3 \
+    --retry-connrefused \
+    "${HTTP_WEB3SIGNER}/upcheck") == 200 ]; then
+        echo "${INFO} web3signer available"
+    else
+        { echo "${ERROR} web3signer not available after 3 minutes, manual migration required"; empty_validator_volume; exit 1; }
+    fi
+
+    # Check if wallet directory exists
+    if [ ! -d ${WALLET_DIR} ]; then
+        { echo "${ERROR} wallet directory not found, manual migration required"; empty_validator_volume; exit 1; }
+    fi
+
+    # Check if wallet password file exists
+    if [ ! -f ${WALLETPASSWORD_FILE} ]; then
+        { echo "${ERROR} wallet password file not found, manual migration required"; empty_validator_volume; exit 1; }
+    fi
+}
+
+# Get VALIDATORS_PUBKEYS as array of strings and as string comma separated
+function get_public_keys() {
+    # Output from validator accounts list
+    # ```
+    # Account 0 | conversely-game-leech
+    # [validating public key] 0xb28d911308c25b9168878abb672c1338e2720ad68fee29bbc27a7c2be4c4efda2696666795e1f8c83ee891e39433b7e5
+
+    # Account 1 | mutually-talented-piranha
+    # [validating public key] 0xa17fb850bed4c509ade62a28025a1ba2cfb2ddfcc7f57f2314671b72452f7b46d7cc5385dde861aa9b109ab1bc2c62f7
+
+    # Account 2 | publicly-renewing-tiger
+    # [validating public key] 0xa7d24732e326207a732fa2f7e2dbc82a476accae977ab31698c31a5f47f5a3f1ab16a2f2a91ea1d5d6eaebe7f01a34a1
+    # ```
+
+    # Get validator pubkeys or exit
+    if VALIDATORS_PUBKEYS=$(validator accounts list \
+    --wallet-dir=${WALLET_DIR} \
+    --wallet-password-file=${WALLETPASSWORD_FILE} \
+    --${NETWORK} \
+    --accept-terms-of-use); then
+        # Grep pubkeys
+        VALIDATORS_PUBKEYS_ARRAY=$(echo ${VALIDATORS_PUBKEYS} | grep -o -E '0x[a-zA-Z0-9]{96}')
+        # Convert to string comma separated
+        PUBLIC_KEYS_COMMA_SEPARATED=$(echo ${VALIDATORS_PUBKEYS_ARRAY} | tr ' ' ',')
+        if [ ! -z "$VALIDATORS_PUBKEYS" ]; then
+            echo "${INFO} Validator pubkeys found: ${VALIDATORS_PUBKEYS}"
+        else
+            { echo "${WARN} no validators found, no migration needed"; empty_validator_volume; exit 0; }
+        fi  
+    else
+        { echo "${ERROR} validator accounts list failed, manual migration required"; empty_validator_volume; exit 1; }
+    fi
+}
+
+# Export validators and slashing protection data
+function export_keystores() {
+    validator accounts backup \
+        --wallet-dir=${WALLET_DIR} \
+        --wallet-password-file=${WALLETPASSWORD_FILE} \
+        --backup-dir=${BACKUP_DIR} \
+        --backup-password-file=${WALLETPASSWORD_FILE} \
+        --backup-public-keys=${PUBLIC_KEYS_COMMA_SEPARATED} \
+        --${NETWORK} \
+        --accept-terms-of-use || { echo "${ERROR} failed to export keystores, manual migration required"; empty_validator_volume; exit 1; }
+
+    unzip -d ${BACKUP_KEYSTORES_DIR} ${BACKUP_ZIP_FILE} || { echo "${ERROR} failed to unzip keystores, manual migration required"; empty_validator_volume; exit 1; }
+}
+
+# Export slashing protection data 
+function export_slashing_protection() {
+    validator slashing-protection-history export \
+        --datadir=${WALLET_DIR} \
+        --slashing-protection-export-dir=${BACKUP_DIR} \
+        --${NETWORK} \
+        --accept-terms-of-use || { echo "${ERROR} failed to export slashing protection, manual migration required"; empty_validator_volume; exit 1; }
+}
+
+# Export walletpassword.txt
+function export_walletpassword() {
+    cp ${WALLETPASSWORD_FILE} ${BACKUP_WALLETPASSWORD_FILE} || { echo "${ERROR} failed to export walletpassword.txt, manual migration required"; empty_validator_volume; exit 1; }
+}
+
+# Create request body file
+function create_request_body() {
+    REQUEST_BODY="$( echo '{}' | jq -c '{ keystores: [], passwords: [], slashing_protection: "" }' )"
+    KEYSTORE_FILES=$(ls ${BACKUP_KEYSTORES_DIR}/*.json)
+    for KEYSTORE_FILE in ${KEYSTORE_FILES}; do
+        KEYSTORE_DATA=$(jq @json <<< $(cat ${KEYSTORE_FILE}))
+        # Append keystores to request body
+        REQUEST_BODY=$(echo ${REQUEST_BODY} | jq -c ".keystores += ["$(echo ${KEYSTORE_DATA})"]")
+        # Append passwords to request body
+        REQUEST_BODY=$(echo ${REQUEST_BODY} | jq -c ".passwords += [\"$(cat ${WALLETPASSWORD_FILE})\"]")
+    done
+    # Append slashing protection to request body
+    SLASHING_DATA=$(jq @json <<< $(cat ${BACKUP_SLASHING_FILE}))
+    REQUEST_BODY=$(echo ${REQUEST_BODY} | jq -c ".slashing_protection += "$(echo ${SLASHING_DATA})"")
+}
+
+# Import validators with request body file
+# - Docs: https://consensys.github.io/web3signer/web3signer-eth2.html#operation/KEYMANAGER_IMPORT
+function import_validators() {
+    curl -X POST \
+        -d ${REQUEST_BODY} \
+        --retry 30 \
+        --retry-delay 3 \
+        --retry-connrefused \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json" \
+        ${HTTP_WEB3SIGNER}/eth/v1/keystores || { echo "${ERROR} failed to import validators, manual migration required"; empty_validator_volume; exit 1; }
+    echo "${INFO} validators imported"
+}
+
+# Remove all content except validator.db amd tosaccepted file
+function empty_validator_volume() {
+    # Moves tosaccepted file to walletdir
+    mv "/root/.eth2/tosaccepted" ${WALLET_DIR}/tosaccepted || echo "${WARN} failed to move tosaccepted file, manual migration required"
+    # Removes old --datadir. Not needed anymore
+    rm -rf "/root/.eth2" || echo "${WARN} failed to remove /root/.eth2"
+    # Removes old validator files: keystores, auth-token and walletpassword.txt
+    rm -rf "${WALLET_DIR}/auth-token" || echo "${WARN} failed to remove ${WALLET_DIR}/auth-token"
+    rm -rf "${WALLET_DIR}/direct" || echo "${WARN} failed to remove ${WALLET_DIR}/direct"
+    rm -rf "${WALLET_DIR}/walletpassword.txt" || echo "${WARN} failed to remove ${WALLET_DIR}/walletpassword.txt"
+    # Removes backup files
+    rm -rf "${BACKUP_DIR}" || echo "${WARN} failed to remove ${BACKUP_DIR}"
+}
+
+########
+# MAIN #
+########
+
+echo "${INFO} ensuring requirements"
+ensure_requirements
+echo "${INFO} getting validator pubkeys"
+get_public_keys
+echo "${INFO} exporting and unzipping keystores"
+export_keystores
+echo "${INFO} exporting slashing protection"
+export_slashing_protection
+echo "${INFO} exporting walletpassword.txt"
+export_walletpassword
+echo "${INFO} creating request body"
+create_request_body
+echo "${INFO} importing validators"
+import_validators
+echo "${INFO} removing wallet dir recursively"
+empty_validator_volume
+
+exit 0

--- a/validator/get-keys-cron
+++ b/validator/get-keys-cron
@@ -1,2 +1,2 @@
 # Run cron job to fetch public keys and redirect output to stdout. This file has permissions 0644. This file must have empty line at the end
-* * * * * root /usr/local/bin/get-keys.sh > /proc/1/fd/1 2>&1
+* * * * * /usr/local/bin/get-keys.sh > /proc/1/fd/1 2>&1

--- a/validator/get-keys-cron
+++ b/validator/get-keys-cron
@@ -1,0 +1,2 @@
+# Run cron job to fetch public keys and redirect output to stdout. This file has permissions 0644. This file must have empty line at the end
+* * * * * root /usr/local/bin/get-keys.sh > /proc/1/fd/1 2>&1

--- a/validator/get-keys.sh
+++ b/validator/get-keys.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# This script must fetch and compare the public keys returned from the web3signer api
+# with the public keys in the public_keys.txt file used to start the validator
+# if the public keys are different, the script will kill the process 1 to restart the process
+# if the public keys are the same, the script will do nothing
+
+ERROR="[ ERROR-cronjob ]"
+WARN="[ WARN-cronjob ]"
+INFO="[ INFO-cronjob ]"
+DEBUG="[ DEBUG-cronjob ]"
+
+# This var must be set here and must be equal to the var defined in the compose file
+PUBLIC_KEYS_FILE="/root/public-keys/public_keys.txt"
+HTTP_WEB3SIGNER="http://web3signer.web3signer-prater.dappnode:9000"
+
+# Get public keys in format: string[]
+function get_public_keys() {
+    if PUBLIC_KEYS=$(curl -s -X GET \
+    -H "Content-Type: application/json" \
+    --max-time 10 \
+    --retry 5 \
+    --retry-delay 2 \
+    --retry-max-time 40 \
+    "${HTTP_WEB3SIGNER}/eth/v1/keystores"); then
+        if PUBLIC_KEYS_PARSED=$(echo ${PUBLIC_KEYS} | jq -r '.data[].validating_pubkey'); then
+            if [ ! -z "$PUBLIC_KEYS_PARSED" ]; then
+                echo "${INFO} found public keys: $PUBLIC_KEYS_PARSED"
+            else
+                echo "${WARN} no public keys found"
+                PUBLIC_KEYS_PARSED=()
+            fi
+        else
+            { echo "${ERROR} something wrong happened parsing the public keys"; exit 1; }
+        fi
+    else
+        { echo "${ERROR} web3signer not available"; exit 1; }
+    fi
+}
+
+# Reads public keys from file by new line separated and converts to string array
+function read_old_public_keys() {
+    if [ -f ${PUBLIC_KEYS_FILE} ]; then
+        echo "${INFO} reading public keys from file"
+        PUBLIC_KEYS_OLD=($(cat ${PUBLIC_KEYS_FILE} | tr '\n' ' '))
+    else
+        echo "${WARN} file ${PUBLIC_KEYS_FILE} not found"
+        PUBLIC_KEYS_OLD=()
+    fi
+}
+
+# Compares the public keys from the file with the public keys from the api
+#   - kill main process if public keys from web3signer api does not contain the public keys from the file
+#   - kill main process if public keys from file does not contain the public keys from the web3signer api
+#   - kill main process if bash array length different
+function compare_public_keys() { 
+    echo "${DEBUG} comparing public keys"
+    echo "${DEBUG} public keys from file: $PUBLIC_KEYS_OLD"
+    echo "${DEBUG} public keys from api: $PUBLIC_KEYS_PARSED"
+    echo "${DEBUG} public keys length from file: ${#PUBLIC_KEYS_OLD[@]}"
+    echo "${DEBUG} public keys length from api: ${#PUBLIC_KEYS_PARSED[@]}"
+
+    # compare array lentghs
+    if [ ${#PUBLIC_KEYS_OLD[@]} -ne ${#PUBLIC_KEYS_PARSED[@]} ]; then
+        echo "${WARN} public keys from file and api are different. Killing process to restart"
+        kill 1
+        exit 0
+    else
+        if [ ${#PUBLIC_KEYS_PARSED[@]} -eq 0 ]; then
+            echo "${INFO} public keys from file and api are empty. Not comparision needed"
+            exit 0
+        else
+            echo "${INFO} same number of public keys, comparing"
+        fi
+    fi
+
+    # Compare public keys
+    for i in "${PUBLIC_KEYS_OLD[@]}"; do
+        if [[ "${PUBLIC_KEYS_PARSED[@]}" =~ "${i}" ]]; then
+            echo "${INFO} public key ${i} found in api"
+        else
+            echo "${WARN} public key ${i} from file not found in api. Killing process to restart"
+            kill 1
+            exit 0
+        fi
+    done
+}
+
+########
+# MAIN #
+########
+
+echo "${INFO} starting cronjob"
+get_public_keys
+read_old_public_keys
+compare_public_keys
+echo "${INFO} finished cronjob"
+exit 0


### PR DESCRIPTION
From Prysm upstream [v2.0.6](https://github.com/prysmaticlabs/prysm/releases), Prysm supports web3signer, this PR will:
- Breaking version v2.0.0, should force a manual update
- Implement web3signer for Prysm
- Remove Prysm UI
- Edit entrypoint
- Implement autoreload keys for web3signer