### PR TITLE
Copy the auth token in runtime

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update && \
 
 #Copy binaries from build stage
 COPY --from=binary /usr/local/bin/validator /usr/local/bin
-COPY auth-token /root/.eth2validators/auth-token
+COPY auth-token /auth-token
 COPY eth2-migrate.sh /usr/local/bin
 COPY entrypoint.sh /usr/local/bin
 

--- a/validator/Dockerfile.dev
+++ b/validator/Dockerfile.dev
@@ -22,7 +22,7 @@ RUN apt update && \
 
 #Copy binaries from build stage
 COPY --from=builder /usr/src/app/prysm/cmd/validator/tmp/validator /usr/local/bin
-COPY auth-token /root/.eth2validators/auth-token
+COPY auth-token /auth-token
 COPY eth2-migrate.sh /usr/local/bin
 COPY entrypoint.sh /usr/local/bin
 

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -6,6 +6,11 @@ VALIDATOR_PORT=3500
 WEB3SIGNER_API="http://web3signer.web3signer-${NETWORK}.dappnode:9000"
 export WALLET_DIR="/root/.eth2validators"
 
+# Copy auth-token in runtime
+mkdir -p ${WALLET_DIR}
+cp /auth-token ${WALLET_DIR}/auth-token
+rm /auth-token
+
 # Migrate if required
 if [[ $(validator accounts list \
   --wallet-dir="$WALLET_DIR" \


### PR DESCRIPTION
In docker there is a prevalence of the docker volumes files against the docker image file structure. If there is a file in the volume it will take the place before.

Copy the auth-token in runtime to ensure it is the good one