### PR TITLE
Add web3 backup provider only if does not exists

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-[[ -n $WEB3_BACKUP ]] && EXTRA_OPTS="--fallback-web3provider=${WEB3_BACKUP} ${EXTRA_OPTS}"
+if [[ -n $WEB3_BACKUP ]] && [[ $WEB3_BACKUP != *"--fallback-web3provider"* ]]; then
+  EXTRA_OPTS="--fallback-web3provider=${WEB3_BACKUP} ${EXTRA_OPTS}"
+fi
+
 if [[ -n $CHECKPOINT_SYNC_URL ]]; then
   EXTRA_OPTS="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL} --genesis-beacon-api-url=${CHECKPOINT_SYNC_URL}"
 else


### PR DESCRIPTION
Adding the `--fallback-web3provider` to the `setup-wizard.yml` was eventually breaking dappnode with this flag already configured due to a double environment set.

**Fix**: check EXTRA_OPTS does not already include this environment variable