### PR TITLE
Add prater naming to envs set in the setup wizard

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -25,7 +25,7 @@ fields:
     title: Add a backup web3 provider
     description: >-
       It's a good idea to add a backup web3 provider in case your main one goes down. For example, if your primary EL client is a local Geth, but you want to use Infura as a backup.
-      Get your web3 backup from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth.mainnet.infura.io)
+      Get your web3 backup from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-prater.infura.io)
     required: false
   - id: checkpointSyncUrl
     target:


### PR DESCRIPTION
Users get confused with the RPC endpoints in the examples. Use the prater name instead of mainnet