### PR TITLE
Implement fee recipient address

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -37,3 +37,14 @@ fields:
       To get Prysm up and running in only a few minutes, you can start Prysm from a recent finalized checkpoint state rather than syncing from genesis. This is substantially **faster** and consumes **less resources** than syncing from genesis, while still providing all the same features. Be sure you are using a trusted node for the fast sync. Check [Prysm docs](https://docs.prylabs.network/docs/prysm-usage/parameters/)
       Get your checkpoint sync from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-prater.infura.io)
     required: false
+  - id: feeRecipientAddress
+    target:
+      type: environment
+      name: FEE_RECIPIENT_ADDRESS
+      service: validator
+    title: Fee Recipient Address
+    description: >-
+      Fee Recipient is a feature that lets you specify a priority fee recipient address on your validator client instance and beacon node. After The Merge, execution clients will begin depositing priority fees into this address whenever your validator client proposes a new block.
+    required: true
+    pattern: "^0x[a-fA-F0-9]{40}$"
+    patternErrorMessage: Must be a valid address (0x1fd16a...)

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -53,6 +53,7 @@ exec -c validator --prater \
   --grpc-gateway-port="$VALIDATOR_PORT" \
   --grpc-gateway-corsdomain=http://0.0.0.0:"$VALIDATOR_PORT" \
   --graffiti=\"$GRAFFITI\" \
+  --suggested-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
   --web \
   --accept-terms-of-use \
   ${EXTRA_OPTS}


### PR DESCRIPTION
Implement fee recipient address during installation through the setup-wizard

For consistency, this value should be set in both services: beacon-chain and validator. See https://github.com/dappnode/DAppNodeSDK/issues/238

Docs: https://docs.prylabs.network/docs/next/execution-node/fee-recipient/#:~:text=Fee%20Recipient%20is%20a%20feature,client%20proposes%20a%20new%20block.