### PR TITLE
Fixed var assignment so EXTRA_OPTS works again

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -5,9 +5,9 @@ if [[ -n $WEB3_BACKUP ]] && [[ $WEB3_BACKUP != *"--fallback-web3provider"* ]]; t
 fi
 
 if [[ -n $CHECKPOINT_SYNC_URL ]]; then
-  EXTRA_OPTS="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL} --genesis-beacon-api-url=${CHECKPOINT_SYNC_URL}"
+  EXTRA_OPTS="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL} --genesis-beacon-api-url=${CHECKPOINT_SYNC_URL} ${EXTRA_OPTS}"
 else
-  EXTRA_OPTS="--genesis-state=/genesis.ssz"
+  EXTRA_OPTS="--genesis-state=/genesis.ssz ${EXTRA_OPTS}"
 fi
 
 exec -c beacon-chain \


### PR DESCRIPTION
Hey,

noticed in discord that some people said the --p2p-max-peer flag doesn't work anymore on Prysm prater and it seems to me that this is caused by wrong var assignments in the new packages. I've fixed it here :)