### PR TITLE
Port standardization

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -11,6 +11,7 @@ else
 fi
 
 exec -c beacon-chain \
+  --accept-terms-of-use \
   --prater \
   --datadir=/data \
   --rpc-host=0.0.0.0 \
@@ -21,5 +22,4 @@ exec -c beacon-chain \
   --http-web3provider=$HTTP_WEB3PROVIDER \
   --grpc-gateway-port=3500 \
   --grpc-gateway-corsdomain=$CORSDOMAIN \
-  --accept-terms-of-use \
   $EXTRA_OPTS

--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -16,6 +16,8 @@ exec -c beacon-chain \
   --rpc-host=0.0.0.0 \
   --grpc-gateway-host=0.0.0.0 \
   --monitoring-host=0.0.0.0 \
+  --p2p-tcp-port=$P2P_TCP_PORT
+  --p2p-udp-port=$P2P_UDP_PORT
   --http-web3provider=$HTTP_WEB3PROVIDER \
   --grpc-gateway-port=3500 \
   --grpc-gateway-corsdomain=$CORSDOMAIN \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,16 @@ services:
     volumes:
       - "beacon-chain-data:/data"
     ports:
-      - "13000"
-      - 12000/udp
+      - "13005:13005/tcp"
+      - "12005:12005/udp"
     restart: unless-stopped
     environment:
       HTTP_WEB3PROVIDER: "http://goerli-geth.dappnode:8545"
       CHECKPOINT_SYNC_URL: ""
       CORSDOMAIN: "http://prysm-prater.dappnode"
       WEB3_BACKUP: ""
+      P2P_TCP_PORT: 13005
+      P2P_UDP_PORT: 12005
       EXTRA_OPTS: ""
   validator:
     image: "validator.prysm-prater.dnp.dappnode.eth:1.0.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,16 @@ services:
     volumes:
       - "beacon-chain-data:/data"
     ports:
-      - "13005:13005/tcp"
-      - "12005:12005/udp"
+      - "13503:13503/tcp"
+      - "12503:12503/udp"
     restart: unless-stopped
     environment:
       HTTP_WEB3PROVIDER: "http://goerli-geth.dappnode:8545"
       CHECKPOINT_SYNC_URL: ""
       CORSDOMAIN: "http://prysm-prater.dappnode"
       WEB3_BACKUP: ""
-      P2P_TCP_PORT: 13005
-      P2P_UDP_PORT: 12005
+      P2P_TCP_PORT: 13503
+      P2P_UDP_PORT: 12503
       EXTRA_OPTS: ""
   validator:
     image: "validator.prysm-prater.dnp.dappnode.eth:1.0.0"


### PR DESCRIPTION
According to this issue https://github.com/dappnode/DAppNode/issues/457
We are selecting the host port for the client.

In prysm client you can change this default ports using these flags:
```
   --p2p-tcp-port value            The port used by libp2p. (default: 13000)
   --p2p-udp-port value            The port used by discv5. (default: 12000)
```



Source: https://docs.prylabs.network/docs/prysm-usage/parameters