### PR TITLE
Fix web3 provider backup example

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -25,7 +25,7 @@ fields:
     title: Add a backup web3 provider
     description: >-
       It's a good idea to add a backup web3 provider in case your main one goes down. For example, if your primary EL client is a local Geth, but you want to use Infura as a backup.
-      Get your web3 backup from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-prater.infura.io)
+      Get your web3 backup from [infura](https://infura.io/) (i.e https://goerli.infura.io/v3/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX)
     required: false
   - id: checkpointSyncUrl
     target:


### PR DESCRIPTION
changed a prater beaconchain infura example link to be a proper looking web3 provider backup

since this is the template its likely present in gnosis and mainnet and testnet clients too