### PR TITLE
Add fee recipient to beacon chain service

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -50,4 +50,5 @@ exec -c beacon-chain \
   --grpc-gateway-port=3500 \
   --grpc-gateway-corsdomain=$CORSDOMAIN \
   --jwt-secret=/jwtsecret \
+  --suggested-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
   $EXTRA_OPTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       P2P_TCP_PORT: 13503
       P2P_UDP_PORT: 12503
       EXTRA_OPTS: ""
+      FEE_RECIPIENT_ADDRESS: ""
   validator:
     image: "validator.prysm-prater.dnp.dappnode.eth:1.0.0"
     build:


### PR DESCRIPTION
The beacon chain is showing the following error if the checkpoint sync is not enabled:
`level=warning msg="In order to receive transaction fees from proposing blocks, you must provide flag --suggested-fee-recipient with a valid ethereum address when starting your beacon node. Please see our documentation for more information on this requirement (https://docs.prylabs.network/docs/execution-node/fee-recipient)." prefix=node
error preparing to initialize genesis db state from local ssz files: error checking existence of ssz-encoded file /genesis.ssz for genesis state init: stat /genesis.ssz: no such file or directory`