### PR TITLE
Add check before setting the fee recipient address

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -37,6 +37,14 @@ if [ -n "$_DAPPNODE_GLOBAL_MEVBOOST_PRATER" ] && [ "$_DAPPNODE_GLOBAL_MEVBOOST_P
   fi
 fi
 
+# Chek the env FEE_RECIPIENT_ADDRESS has a valid ethereum address if not set to the null address
+if [ -n "$FEE_RECIPIENT_ADDRESS" ] && [[ "$FEE_RECIPIENT_ADDRESS" =~ ^0x[a-fA-F0-9]{40}$ ]]; then
+    echo "FEE_RECIPIENT is valid"
+else
+    echo "FEE_RECIPIENT is not a valid ethereum address, setting it to the null address"
+    FEE_RECIPIENT_ADDRESS="0x0000000000000000000000000000000000000000"
+fi
+
 exec -c beacon-chain \
   --datadir=/data \
   --rpc-host=0.0.0.0 \


### PR DESCRIPTION
The fee recipient is set to the burn address if the fee recipient set is not a valid Ethereum address