### PR TITLE
bump prysmaticlabs/prysm to v4.0.5

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm-prater.dnp.dappnode.eth",
-  "version": "1.0.22",
-  "upstreamVersion": "v4.0.4",
+  "version": "1.0.24",
+  "upstreamVersion": "v4.0.5",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm implementation for Prater Beacon chain + validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v4.0.4
+        UPSTREAM_VERSION: v4.0.5
     volumes:
       - "beacon-chain-data:/data"
     ports:
@@ -25,7 +25,7 @@ services:
       context: validator
       dockerfile: Dockerfile
       args:
-        UPSTREAM_VERSION: v4.0.4
+        UPSTREAM_VERSION: v4.0.5
         BRANCH: develop
     volumes:
       - "validator-data:/root/"


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v4.0.4 to [v4.0.5](https://github.com/prysmaticlabs/prysm/releases/tag/v4.0.5)